### PR TITLE
Add link in show page for belongs to associations

### DIFF
--- a/app/views/krudmin/application/fields/belongs_to/_show.html.haml
+++ b/app/views/krudmin/application/fields/belongs_to/_show.html.haml
@@ -1,0 +1,5 @@
+//= form.association association_name, collection: associated_options, label_method: collection_label_field, value_method: :id, input_html: {class: 'form-control select2', include_blank: true}
+- if linkable
+  = link_to humanized_value, link_to_association.call(self)
+- else
+  = humanized_value

--- a/app/views/krudmin/application/fields/enum_type/_show.html.haml
+++ b/app/views/krudmin/application/fields/enum_type/_show.html.haml
@@ -1,1 +1,1 @@
-= enum_text
+= humanize_value

--- a/app/views/krudmin/application/fields/enum_type/_show.html.haml
+++ b/app/views/krudmin/application/fields/enum_type/_show.html.haml
@@ -1,0 +1,1 @@
+= enum_text

--- a/app/views/krudmin/application/show.html.haml
+++ b/app/views/krudmin/application/show.html.haml
@@ -21,4 +21,4 @@
                 %th
                   = model_class.human_attribute_name(attribute)
                 %td
-                  = field_for(attribute, model).render(:list, self)
+                  = field_for(attribute, model).render(:show, self)

--- a/lib/krudmin/fields/associated.rb
+++ b/lib/krudmin/fields/associated.rb
@@ -34,7 +34,6 @@ module Krudmin
       end
 
       private
-
       def inferred_resource_manager
         "#{associated_class_name.pluralize}ResourceManager"
       end

--- a/lib/krudmin/fields/associated.rb
+++ b/lib/krudmin/fields/associated.rb
@@ -24,6 +24,20 @@ module Krudmin
       def association_predicate
         @association_predicate ||= options.fetch(:association_predicate, ->(source) { source.all })
       end
+
+      def associated_resource_manager_class_name
+        @associated_resource_manager_class_name ||= options.fetch(:resource_manager, inferred_resource_manager).to_s
+      end
+
+      def associated_resource_manager_class
+        @associated_resource_manager_class ||= associated_resource_manager_class_name.constantize
+      end
+
+      private
+
+      def inferred_resource_manager
+        "#{associated_class_name.pluralize}ResourceManager"
+      end
     end
   end
 end

--- a/lib/krudmin/fields/associated.rb
+++ b/lib/krudmin/fields/associated.rb
@@ -34,6 +34,7 @@ module Krudmin
       end
 
       private
+
       def inferred_resource_manager
         "#{associated_class_name.pluralize}ResourceManager"
       end

--- a/lib/krudmin/fields/belongs_to.rb
+++ b/lib/krudmin/fields/belongs_to.rb
@@ -13,12 +13,24 @@ module Krudmin
         model.send(association_name)
       end
 
+      def humanized_value
+        selected_association.send(collection_label_field)
+      end
+
       def collection_label_field
         @collection_label_field ||= options.fetch(:collection_label_field, :label)
       end
 
       def associated_options
         @associated_options ||= association_predicate.call(associated_class)
+      end
+
+      def link_to_path(view_context)
+        view_context.send(association_path, selected_association)
+      end
+
+      def association_path
+        options[:association_path]
       end
     end
   end

--- a/lib/krudmin/fields/enum_type.rb
+++ b/lib/krudmin/fields/enum_type.rb
@@ -9,7 +9,7 @@ module Krudmin
         @enum_value ||= model.send("#{attribute}_before_type_cast") if model
       end
 
-      def enum_text
+      def humanize_value
         @enum_text ||= associated_options.key(enum_value) if associated_options.any?
       end
 

--- a/lib/krudmin/fields/enum_type.rb
+++ b/lib/krudmin/fields/enum_type.rb
@@ -9,6 +9,10 @@ module Krudmin
         @enum_value ||= model.send("#{attribute}_before_type_cast") if model
       end
 
+      def enum_text
+        @enum_text ||= associated_options.key(enum_value) if associated_options.any?
+      end
+
       # TODO: Refactor, infer associated options
       # def associated_options
       #   @associated_options ||= association_predicate.call(associated_class)
@@ -16,6 +20,10 @@ module Krudmin
 
       def associated_options
         options.fetch(:associated_options).call
+      end
+
+      def linkable
+        false
       end
     end
   end

--- a/lib/krudmin/fields/has_many.rb
+++ b/lib/krudmin/fields/has_many.rb
@@ -43,14 +43,6 @@ module Krudmin
         @association_predicate ||= options.fetch(:association_predicate, ->(source) { source.where(foreign_key => primary_key_value) })
       end
 
-      def associated_resource_manager_class_name
-        @associated_resource_manager_class_name ||= options.fetch(:resource_manager, inferred_resource_manager).to_s
-      end
-
-      def associated_resource_manager_class
-        @associated_resource_manager_class ||= associated_resource_manager_class_name.constantize
-      end
-
       def self.editable_attribute(attribute)
         new(attribute).editable_attribute
       end
@@ -64,12 +56,6 @@ module Krudmin
           attribute => options,
           __attributes: Krudmin::ResourceManagers::Attribute.from_list(new(attribute).associated_resource_manager_class::ATTRIBUTE_TYPES),
         }
-      end
-
-      private
-
-      def inferred_resource_manager
-        "#{associated_class_name.pluralize}ResourceManager"
       end
     end
   end

--- a/lib/krudmin/presenters/belongs_to_field_presenter.rb
+++ b/lib/krudmin/presenters/belongs_to_field_presenter.rb
@@ -1,7 +1,9 @@
 module Krudmin
   module Presenters
     class BelongsToFieldPresenter < BaseFieldPresenter
-      delegate :associated_options, :collection_label_field, :association_name, to: :field
+      delegate :associated_options, :collection_label_field, :association_name, :association_path, :link_to_path, :humanized_value, to: :field
+
+      alias linkable? association_path
 
       def render_form
         render_partial(:form, association_name: association_name, associated_options: associated_options, collection_label_field: collection_label_field)
@@ -14,6 +16,12 @@ module Krudmin
                                 collection_label_field: collection_label_field,
                                 search_value: search_value,
                                 options_attribute: options_attribute)
+      end
+
+      def render_show
+        render_partial(:show, humanized_value: humanized_value,
+                              linkable: linkable?,
+                              link_to_association: ->(view_context) { link_to_path(view_context) })
       end
     end
   end

--- a/lib/krudmin/presenters/enum_type_field_presenter.rb
+++ b/lib/krudmin/presenters/enum_type_field_presenter.rb
@@ -1,10 +1,14 @@
 module Krudmin
   module Presenters
     class EnumTypeFieldPresenter < BelongsToFieldPresenter
-      delegate :associated_options, :enum_value, to: :field
+      delegate :associated_options, :enum_value, :enum_text, to: :field
 
       def render_form
         render_partial(:form, associated_options: associated_options, enum_value: enum_value)
+      end
+
+      def render_show
+        render_partial(:show, enum_text: enum_text)
       end
     end
   end

--- a/lib/krudmin/presenters/enum_type_field_presenter.rb
+++ b/lib/krudmin/presenters/enum_type_field_presenter.rb
@@ -1,14 +1,14 @@
 module Krudmin
   module Presenters
     class EnumTypeFieldPresenter < BelongsToFieldPresenter
-      delegate :associated_options, :enum_value, :enum_text, to: :field
+      delegate :associated_options, :enum_value, :humanize_value, to: :field
 
       def render_form
         render_partial(:form, associated_options: associated_options, enum_value: enum_value)
       end
 
       def render_show
-        render_partial(:show, enum_text: enum_text)
+        render_partial(:show, humanize_value: humanize_value)
       end
     end
   end

--- a/lib/krudmin/presenters/has_many_field_presenter.rb
+++ b/lib/krudmin/presenters/has_many_field_presenter.rb
@@ -17,7 +17,7 @@ module Krudmin
         "#{partial_path}/#{child_partial_form}"
       end
 
-      def render_list
+      def render_show
         render_partial(partial_display, options: options, field: field, render_partial: method(:render_partial))
       end
 

--- a/lib/krudmin/presenters/rich_text_field_presenter.rb
+++ b/lib/krudmin/presenters/rich_text_field_presenter.rb
@@ -5,11 +5,9 @@ module Krudmin
         render_partial(:form)
       end
 
-      def render_list
+      def render_show
         value&.html_safe
       end
-
-      alias_method :render_show, :render_list
     end
   end
 end

--- a/spec/features/car_show_spec.rb
+++ b/spec/features/car_show_spec.rb
@@ -2,17 +2,42 @@ require "rails_helper"
 
 describe "line item index page", type: :feature do
   let(:car_model) { "Camry" }
-  let(:new_car_model) { "Tacoma" }
-  let!(:car) { create(:car, model: car_model) }
+
+  let!(:car_brand) { create(:car_brand, description: "Toyota") }
+
+  let!(:car) { create(:car, model: car_model, car_brand: car_brand) }
+  let!(:passenger1) { create(:passenger, gender: 0, car: car) }
+  let!(:passenger2) { create(:passenger, gender: 1, car: car) }
 
   let(:car_page) { CarPage.new(url: admin_cars_path, model: car) }
 
   before do
     car_page.visit_page
+    click_show_link_for(car)
   end
 
   it "links to the show page of a given item" do
-    click_show_link_for(car)
-    expect(car_page).to have_content("Camry")
+    expect(car_page).to have_text "Camry"
+    expect(car_page).to have_text "CK0000000001"
+    expect(car_page).to have_text car.year, count: 1
+    expect(car_page).to have_text "Toyota", count: 1
+  end
+
+  it "shows a link to car model" do
+    expect(car_page).to have_selector :link, "Toyota", href: "/admin/car_brands/#{car_brand.id}"
+  end
+
+  it "shows a link to edit the car" do
+    expect(car_page).to have_selector :link, "Edit Camry", href: "/admin/cars/#{car.id}/edit"
+  end
+
+  it "shows the passengers list" do
+    expect(car_page).to have_text passenger1.name, count: 1
+    expect(car_page).to have_text passenger1.age
+    expect(car_page).to have_text "male"
+
+    expect(car_page).to have_text passenger2.name, count: 1
+    expect(car_page).to have_text passenger2.age
+    expect(car_page).to have_text "female"
   end
 end

--- a/spec/lib/krudmin/fields/belongs_to_spec.rb
+++ b/spec/lib/krudmin/fields/belongs_to_spec.rb
@@ -48,6 +48,15 @@ describe Krudmin::Fields::BelongsTo do
       end
     end
 
+    describe "humanized_value" do
+      subject { described_class.new(:ranger_id, model, collection_label_field: :name) }
+
+      it "returns the humanized string from value" do
+        expect(subject.humanized_value).not_to be(nil)
+        expect(subject.humanized_value).to eq(Ranger.main.name)
+      end
+    end
+
     describe "selected_association" do
       it "returns the associated model from value" do
         expect(subject.selected_association).not_to be(nil)
@@ -62,10 +71,32 @@ describe Krudmin::Fields::BelongsTo do
     end
 
     describe "associated_options" do
-      subject { described_class.new(:ranger_id, model, {association_predicate: -> (source) { source.main }}) }
+      subject { described_class.new(:ranger_id, model, association_predicate: ->(source) { source.main }) }
 
       it "executes the main method as the given scope" do
         expect(subject.associated_options).to eq(Ranger.main)
+      end
+    end
+
+    describe "association_path" do
+      subject { described_class.new(:ranger_id, model, association_path: :test_path) }
+
+      it "is extracted from options" do
+        expect(subject.association_path).to eq(:test_path)
+      end
+    end
+
+    describe "link_to_path" do
+      subject { described_class.new(:ranger_id, model, association_path: :test_path) }
+      let(:view_context) { double }
+
+      it "returns the path of the associated selected model" do
+        allow(view_context).to receive(:test_path) do |model|
+          expect(model).to eq(Ranger.main)
+          "/test/show/#{model.id}"
+        end
+
+        expect(subject.link_to_path(view_context)).to eq("/test/show/1")
       end
     end
   end

--- a/spec/lib/krudmin/fields/belongs_to_spec.rb
+++ b/spec/lib/krudmin/fields/belongs_to_spec.rb
@@ -3,26 +3,25 @@ require "#{Dir.pwd}/lib/krudmin/activable_labeler"
 require "#{Dir.pwd}/lib/krudmin/fields/base"
 require "#{Dir.pwd}/lib/krudmin/fields/associated"
 require "#{Dir.pwd}/lib/krudmin/fields/belongs_to"
+module Ranger
+  class << self
+    def all
+      [
+        OpenStruct.new(name: "Rambo", id: 1),
+        OpenStruct.new(name: "Chuck Norris", id: 2),
+        OpenStruct.new(name: "Arnold", id: 3)
+      ]
+    end
 
-describe Krudmin::Fields::BelongsTo do
-  let(:model) { double(ranger_id: 1, ranger: Ranger.main) }
-  subject { described_class.new(:ranger_id, model) }
-
-  module Ranger
-    class << self
-      def all
-        [
-          OpenStruct.new(name: "Rambo", id: 1),
-          OpenStruct.new(name: "Chuck Norris", id: 2),
-          OpenStruct.new(name: "Arnold", id: 3)
-        ]
-      end
-
-      def main
-        all.first
-      end
+    def main
+      all.first
     end
   end
+end
+
+describe Krudmin::Fields::BelongsTo do
+  let(:model) { double(ranger_id: 1, ranger: Ranger.all.first) }
+  subject { described_class.new(:ranger_id, model) }
 
   describe "collection_label_field" do
     context "default" do
@@ -53,14 +52,14 @@ describe Krudmin::Fields::BelongsTo do
 
       it "returns the humanized string from value" do
         expect(subject.humanized_value).not_to be(nil)
-        expect(subject.humanized_value).to eq(Ranger.main.name)
+        expect(subject.humanized_value).to eq("Rambo")
       end
     end
 
     describe "selected_association" do
       it "returns the associated model from value" do
         expect(subject.selected_association).not_to be(nil)
-        expect(subject.selected_association).to eq(Ranger.main)
+        expect(subject.selected_association).to eq(Ranger.all.first)
       end
     end
 
@@ -92,7 +91,7 @@ describe Krudmin::Fields::BelongsTo do
 
       it "returns the path of the associated selected model" do
         allow(view_context).to receive(:test_path) do |model|
-          expect(model).to eq(Ranger.main)
+          expect(model).to eq(Ranger.all.first)
           "/test/show/#{model.id}"
         end
 

--- a/spec/test_app/app/resource_managers/cars_resource_manager.rb
+++ b/spec/test_app/app/resource_managers/cars_resource_manager.rb
@@ -6,7 +6,7 @@ class CarsResourceManager < Krudmin::ResourceManagers::Base
     activation: [:model, :year, :car_brand_id, :transmission],
     passengers: [:passengers],
   }
-  DISPLAYABLE_ATTRIBUTES = [:id, :model, :year, :description, :transmission, :passengers, :created_at]
+  DISPLAYABLE_ATTRIBUTES = [:id, :model, :year, :description, :transmission, :car_brand_id, :passengers, :created_at]
   SEARCHABLE_ATTRIBUTES = [:model, :year, :active, :car_brand_id, :transmission, :created_at]
   LISTABLE_ACTIONS = [:show, :edit, :active, :destroy]
   LISTABLE_ATTRIBUTES = [:model, :id, :car_brand_description, :year, :active, :description, :created_at]
@@ -31,7 +31,7 @@ class CarsResourceManager < Krudmin::ResourceManagers::Base
     year: Krudmin::Fields::Number,
     active: Krudmin::Fields::Boolean,
     passengers: Krudmin::Fields::HasMany,
-    car_brand_id: { type: Krudmin::Fields::BelongsTo, collection_label_field: :description },
+    car_brand_id: { type: Krudmin::Fields::BelongsTo, collection_label_field: :description, association_path: :admin_car_brand_path },
     created_at: { type: Krudmin::Fields::DateTime, format: :short },
     transmission: { type: Krudmin::Fields::EnumType, associated_options: -> { Car.transmissions } },
   }

--- a/spec/test_app/spec/factories/passengers.rb
+++ b/spec/test_app/spec/factories/passengers.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :passenger do
+    name { FFaker::Name.name }
+    age { (2000..2010).to_a.sample }
+    gender { (0..1).to_a.sample }
+    association :car
+  end
+end

--- a/spec/test_app/spec/factories/passengers.rb
+++ b/spec/test_app/spec/factories/passengers.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :passenger do
     name { FFaker::Name.name }
-    age { (2000..2010).to_a.sample }
+    age { (1960..2018).to_a.sample }
     gender { (0..1).to_a.sample }
     association :car
   end


### PR DESCRIPTION
Fixes #51 

This adds a new `association_path` option to the belongs_to field type. 