### PR TITLE
Infer field type from strings and symbols

### DIFF
--- a/lib/krudmin/resource_managers/attribute.rb
+++ b/lib/krudmin/resource_managers/attribute.rb
@@ -25,7 +25,7 @@ module Krudmin
         when Symbol, String
           "Krudmin::Fields::#{source}".constantize
         when Hash
-          {type: find_field_klass(source[:type])}.reverse_merge(source)
+          { type: find_field_klass(source[:type]) }.reverse_merge(source)
         else
           source
         end

--- a/lib/krudmin/resource_managers/attribute_collection.rb
+++ b/lib/krudmin/resource_managers/attribute_collection.rb
@@ -22,15 +22,15 @@ module Krudmin
 
       def grouped_attributes
         @grouped_attributes ||= if attributes.is_a?(Hash)
-          attributes.reduce({}) do |hash, value|
-            key = value.first
-            attributes = value.last
-            hash[key] = { attributes: attributes }.merge(presentation_metadata.fetch(key))
-            hash
-          end
-        else
-          { general: { attributes: attributes, label: "General" } }
-        end
+                                  attributes.reduce({}) do |hash, value|
+                                    key = value.first
+                                    attributes = value.last
+                                    hash[key] = { attributes: attributes }.merge(presentation_metadata.fetch(key))
+                                    hash
+                                  end
+                                else
+                                  { general: { attributes: attributes, label: "General" } }
+                                end
       end
 
       def editable_attributes

--- a/lib/krudmin/resource_managers/attribute_collection.rb
+++ b/lib/krudmin/resource_managers/attribute_collection.rb
@@ -22,15 +22,15 @@ module Krudmin
 
       def grouped_attributes
         @grouped_attributes ||= if attributes.is_a?(Hash)
-                                  attributes.reduce({}) do |hash, value|
-                                    key = value.first
-                                    attributes = value.last
-                                    hash[key] = { attributes: attributes }.merge(presentation_metadata.fetch(key))
-                                    hash
-                                  end
-                                else
-                                  { general: { attributes: attributes, label: "General" } }
-                                end
+          attributes.reduce({}) do |hash, value|
+            key = value.first
+            attributes = value.last
+            hash[key] = { attributes: attributes }.merge(presentation_metadata.fetch(key))
+            hash
+          end
+        else
+          { general: { attributes: attributes, label: "General" } }
+        end
       end
 
       def editable_attributes
@@ -53,10 +53,10 @@ module Krudmin
 
       def attribute_types
         @attribute_types ||= attributes_metadata.reduce({}) do |hash, item|
-          attribute = item.first
-          options = item.last
 
-          hash[attribute] = Attribute.from(attribute, options)
+          attribute = item.first 
+
+          hash[attribute] = Attribute.from(attribute, item.last)
           hash
         end
       end

--- a/lib/krudmin/resource_managers/attribute_collection.rb
+++ b/lib/krudmin/resource_managers/attribute_collection.rb
@@ -53,8 +53,7 @@ module Krudmin
 
       def attribute_types
         @attribute_types ||= attributes_metadata.reduce({}) do |hash, item|
-
-          attribute = item.first 
+          attribute = item.first
 
           hash[attribute] = Attribute.from(attribute, item.last)
           hash

--- a/spec/lib/krudmin/resource_managers/attribute_collection_spec.rb
+++ b/spec/lib/krudmin/resource_managers/attribute_collection_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 require "#{Dir.pwd}/lib/krudmin/fields/base"
 require "#{Dir.pwd}/lib/krudmin/fields/string"
 require "#{Dir.pwd}/lib/krudmin/fields/number"
+require "#{Dir.pwd}/lib/krudmin/fields/text"
 require "#{Dir.pwd}/lib/krudmin/resource_managers/attribute"
 require "#{Dir.pwd}/lib/krudmin/resource_managers/attribute_collection"
 
@@ -32,13 +33,14 @@ describe Krudmin::ResourceManagers::AttributeCollection do
       let(:attribute_types) do
         {
           name: Krudmin::Fields::String,
-          age: Krudmin::Fields::Number
+          age: :Number,
+          description: "Text",
         }
       end
 
       it "returns an empty hash if no values are provided" do
         expect(subject.attribute_types.values.map(&:class).uniq).to eq([Krudmin::ResourceManagers::Attribute])
-        expect(subject.attribute_types.values.map(&:type)).to eq([Krudmin::Fields::String, Krudmin::Fields::Number])
+        expect(subject.attribute_types.values.map(&:type)).to eq([Krudmin::Fields::String, Krudmin::Fields::Number, Krudmin::Fields::Text])
       end
     end
   end

--- a/spec/test_app/app/resource_managers/cars_resource_manager.rb
+++ b/spec/test_app/app/resource_managers/cars_resource_manager.rb
@@ -25,15 +25,15 @@ class CarsResourceManager < Krudmin::ResourceManagers::Base
   }
 
   ATTRIBUTE_TYPES = {
-    id: { type: Krudmin::Fields::Number, padding: 10, prefix: :CK },
-    model: { type: Krudmin::Fields::Text, input: { rows: 2 } },
-    description: { type: Krudmin::Fields::RichText, show_length: 20 },
-    year: Krudmin::Fields::Number,
-    active: Krudmin::Fields::Boolean,
-    passengers: Krudmin::Fields::HasMany,
-    car_brand_id: { type: Krudmin::Fields::BelongsTo, collection_label_field: :description, association_path: :admin_car_brand_path },
-    created_at: { type: Krudmin::Fields::DateTime, format: :short },
-    release_date: { type: Krudmin::Fields::Date, format: :short },
-    transmission: { type: Krudmin::Fields::EnumType, associated_options: -> { Car.transmissions } },
+    id: { type: :Number, padding: 10, prefix: :CK },
+    model: { type: :Text, input: { rows: 2 } },
+    description: { type: :RichText, show_length: 20 },
+    year: :Number,
+    active: :Boolean,
+    passengers: :HasMany,
+    car_brand_id: { type: :BelongsTo, collection_label_field: :description, association_path: :admin_car_brand_path },
+    created_at: { type: :DateTime, format: :short },
+    release_date: { type: :Date, format: :short },
+    transmission: { type: :EnumType, associated_options: -> { Car.transmissions } },
   }
 end

--- a/spec/test_app/app/resource_managers/passengers_resource_manager.rb
+++ b/spec/test_app/app/resource_managers/passengers_resource_manager.rb
@@ -3,9 +3,9 @@ class PassengersResourceManager < Krudmin::ResourceManagers::Base
   MODEL_CLASSNAME = "Passenger"
 
   ATTRIBUTE_TYPES = {
-    name: Krudmin::Fields::String,
-    age: Krudmin::Fields::Number,
-    email: Krudmin::Fields::Email,
-    gender: {type: Krudmin::Fields::EnumType, associated_options: -> { Passenger.genders }}
+    name: "String",
+    age: "Number",
+    email: :Email,
+    gender: {type: :EnumType, associated_options: -> { Passenger.genders }}
   }
 end


### PR DESCRIPTION
### Adds the ability to use Symbols and Strings in order to represent the type of a field

##### e.g:

```ruby
  ATTRIBUTE_TYPES = {
    name: "String",
    age: "Number",
    email: :Email,
    gender: {type: :EnumType, associated_options: -> { Passenger.genders }}
  }
```

### Full canonical names for classes are also supported

```ruby
{type: Krudmin::Fields::Number, decimals: 3}
```