### PR TITLE
Defined access methods for actions

### DIFF
--- a/app/controllers/concerns/krudmin/krudmin_controller_support.rb
+++ b/app/controllers/concerns/krudmin/krudmin_controller_support.rb
@@ -20,6 +20,14 @@ module Krudmin
 
         delegate defined_method, to: :krudmin_router
         helper_method defined_method
+
+        defined_access_method = "#{action_name}_access?"
+
+        helper_method defined_access_method
+
+        define_method(defined_access_method) do |*args|
+          defined?(super(*args)) ? super(*args) && method(defined_method).call : method(defined_method).call
+        end
       end
     end
 

--- a/app/views/krudmin/core_theme/action_buttons/active_button/_form.html.haml
+++ b/app/views/krudmin/core_theme/action_buttons/active_button/_form.html.haml
@@ -1,8 +1,8 @@
-- if model.active? && deactivate_route?
+- if model.active? && deactivate_access?
   = link_to(deactivate_path(model, context: :form), method: :post, remote: true, data: {confirm: confirm_deactivation_message(model)}, class: "btn btn-warning btn-disable btn-deactivate-item") do
     %i.fa.fa-times
     = t('krudmin.actions.deactivate')
-- elsif !model.active? && activate_route?
+- elsif !model.active? && activate_access?
   = link_to(activate_path(model, context: :form), method: :post, remote: true, data: {confirm: confirm_activation_message(model) }, class: "btn btn-success btn-enable btn-activate-item") do
     %i.fa.fa-check
     = t('krudmin.actions.activate')

--- a/app/views/krudmin/core_theme/action_buttons/active_button/_list.html.haml
+++ b/app/views/krudmin/core_theme/action_buttons/active_button/_list.html.haml
@@ -1,7 +1,7 @@
 %li.list-inline-item
-  - if model.active? && deactivate_route?
+  - if model.active? && deactivate_access?
     = link_to(deactivate_path(model), method: :post, remote: true, data: {confirm: confirm_deactivation_message(model)}, class: "btn btn-outline-warning btn-disable btn-deactivate-item") do
       %i.fa.fa-times
-  - elsif !model.active? && activate_route?
+  - elsif !model.active? && activate_access?
     = link_to(activate_path(model), method: :post, remote: true, data: {confirm: confirm_activation_message(model) }, class: "btn btn-outline-success btn-enable btn-activate-item") do
       %i.fa.fa-check

--- a/app/views/krudmin/core_theme/action_buttons/destroy_button/_list.html.haml
+++ b/app/views/krudmin/core_theme/action_buttons/destroy_button/_list.html.haml
@@ -1,4 +1,4 @@
-- if destroy_route?
+- if destroy_access?
   .list-inline-item
     = link_to(resource_path(model), method: :delete, remote: true, data: {confirm: confirm_destroy_message(model)}, class: "btn btn-outline-danger delete-btn btn-destroy-item") do
       %i.fa.fa-trash

--- a/app/views/krudmin/core_theme/action_buttons/edit_button/_form.html.haml
+++ b/app/views/krudmin/core_theme/action_buttons/edit_button/_form.html.haml
@@ -1,4 +1,4 @@
-- if edit_route?
+- if edit_access?
   = link_to edit_resource_path(model), class: "btn btn-success" do
     %i.fa.fa-pencil
     = crud_title

--- a/app/views/krudmin/core_theme/action_buttons/edit_button/_list.html.haml
+++ b/app/views/krudmin/core_theme/action_buttons/edit_button/_list.html.haml
@@ -1,4 +1,4 @@
-- if edit_route?
+- if edit_access?
   %li.list-inline-item
     = link_to edit_resource_path(model), class: "btn btn-outline-primary btn-edit-item" do
       %i.fa.fa-pencil

--- a/app/views/krudmin/core_theme/action_buttons/new_button/_list.html.haml
+++ b/app/views/krudmin/core_theme/action_buttons/new_button/_list.html.haml
@@ -1,4 +1,4 @@
-- if new_route?
+- if new_access?
   = link_to(action_path, class: 'btn btn-success') do
     %i.fa.fa-plus
     = t('krudmin.actions.add_new')

--- a/app/views/krudmin/core_theme/action_buttons/show_button/_form.html.haml
+++ b/app/views/krudmin/core_theme/action_buttons/show_button/_form.html.haml
@@ -1,4 +1,4 @@
-- if show_route? && !model.new_record?
+- if show_access? && !model.new_record?
   = link_to(resource_path(model), class: "btn btn-secondary") do
     %i.fa.fa-eye
     = t('krudmin.actions.show')

--- a/app/views/krudmin/core_theme/action_buttons/show_button/_list.html.haml
+++ b/app/views/krudmin/core_theme/action_buttons/show_button/_list.html.haml
@@ -1,4 +1,4 @@
-- if show_route?
+- if show_access?
   %li.list-inline-item
     = link_to(resource_path(model), class: "btn btn-outline-secondary btn-show-item") do
       %i.fa.fa-eye

--- a/app/views/krudmin/core_theme/index.html.haml
+++ b/app/views/krudmin/core_theme/index.html.haml
@@ -35,8 +35,8 @@
               %tr{class: "item-model-#{item.id}"}
                 - listable_attributes.each_with_index do |column_label, column_index|
                   %td{class: "#{krudmin_manager.field_for(column_label).html_class}"}
-                    - if column_index.zero? && (edit_route? || show_route?)
-                      = link_to(field_for(column_label, item).render(:list, self), edit_route? ? edit_resource_path(item.id) : resource_path(item.id))
+                    - if column_index.zero? && (edit_access? || show_access?)
+                      = link_to(field_for(column_label, item).render(:list, self), edit_access? ? edit_resource_path(item.id) : resource_path(item.id))
                     - else
                       = field_for(column_label, item).render(:list, self)
                 - if listable_actions.any?

--- a/lib/krudmin/resource_managers/routing.rb
+++ b/lib/krudmin/resource_managers/routing.rb
@@ -1,7 +1,7 @@
 module Krudmin
   module ResourceManagers
     class Routing
-      DEFINED_ACTION_METHODS = [:edit, :show, :destroy, :new, :activate, :deactivate].freeze
+      DEFINED_ACTION_METHODS = [:index, :edit, :show, :destroy, :new, :activate, :deactivate].freeze
 
       DEFINED_ACTION_METHODS.each do |action_name|
         define_method("#{action_name}_route?") do

--- a/spec/test_app/config/initializers/krudmin.rb
+++ b/spec/test_app/config/initializers/krudmin.rb
@@ -10,6 +10,8 @@ Krudmin::Config.with do |config|
       menu.link "Dog Breeds", :admin_dog_breeds_path, module_path: :admin, icon: :paw
     end
   }
+
+  config.parent_controller = 'ApplicationController'
 end
 
 Krudmin::config do |cfg|


### PR DESCRIPTION
### Define overridable `_access?` methods in order to verify wether or not an action is available on a given context. This verifies if the route for the action is valid. Overriding the return value of this methods in parent controllers is a good way to restrict which buttons and links should be displayed.

- index_access?
- edit_access?
- show_access?
- destroy_access?
- new_access?
- activate_access?
- deactivat_access?