### PR TITLE
Ux improv search and card boxes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    krudmin (0.1.7.8)
+    krudmin (0.1.7.9)
       arbre
       bootstrap (~> 4.0.0)
       cocoon

--- a/app/assets/javascripts/krudmin/core_theme/app.js
+++ b/app/assets/javascripts/krudmin/core_theme/app.js
@@ -24,6 +24,10 @@ function initScripts() {
   $('.alert.alert-info').delay( 5000 ).fadeOut( 400 );
 }
 
+function controllerPath() {
+  return `${$('body').data('controller')}-${$('body').data('action')}`;
+}
+
 document.addEventListener("turbofroms:updated", function(e) {
 });
 

--- a/app/assets/javascripts/krudmin/core_theme/app.js
+++ b/app/assets/javascripts/krudmin/core_theme/app.js
@@ -175,8 +175,6 @@ document.addEventListener('turbolinks:load', function(event) {
       iconEl.className = iconEl.className.replace('fa-chevron-down', 'fa-chevron-up');
       sessionStorage.removeItem(panelPath);
     }
-
-    console.log(panelPath);
   });
 
   /* ---------- Main Menu Open/Close, Min/Full ---------- */
@@ -202,9 +200,18 @@ document.addEventListener('turbolinks:load', function(event) {
     resizeBroadcast();
   });
 
+  $('.search-panel-displayer').click(function () {
+    $('.search-panel').show('fast');
+    resizeBroadcast();
+
+    $("html, body").animate({ scrollTop: 0 }, "fast");
+  });
+
   $('.search-panel-toggler').click(function () {
     $('.search-panel').slideToggle('fast');
     resizeBroadcast();
+
+    $("html, body").animate({ scrollTop: 0 }, "fast");
   });
 
   $('.mobile-sidebar-toggler').click(function(){
@@ -258,4 +265,11 @@ function init(url) {
   /* ---------- Popover ---------- */
   $('[rel="popover"],[data-rel="popover"],[data-toggle="popover"]').popover();
 
+}
+
+function blinkHighlight(el, from, to) {
+  if (!from) { from = 0.5; }
+  if (!to) { to = 1.0; }
+
+  $(el).fadeTo(100, from).fadeTo(200, to);
 }

--- a/app/assets/javascripts/krudmin/core_theme/app.js
+++ b/app/assets/javascripts/krudmin/core_theme/app.js
@@ -25,13 +25,14 @@ function initScripts() {
 }
 
 function controllerPath() {
-  return `${$('body').data('controller')}-${$('body').data('action')}`;
+  return [$('body').data('controller'), $('body').data('action')].join("-");
 }
 
 function panelNameFor(cardEl) {
   var cPath = controllerPath();
   var panelName = cardEl.data("card-panel");
-  return `${cPath}-${panelName}`;
+
+  return [cPath, panelName].join("-");
 }
 
 document.addEventListener("turbofroms:updated", function(e) {
@@ -161,7 +162,7 @@ document.addEventListener('turbolinks:load', function(event) {
     var iconEl = $(this).find('i').get(0);
     var cardEl = $(this).closest('.card');
     var panelName = cardEl.data("card-panel");
-    var panelPath = `${cPath}-${panelName}`;
+    var panelPath = [cPath, panelName].join('-');
     var cardBody = cardEl.find('.card-body');
     var goesUp = iconEl.classList.contains("fa-chevron-up");
 

--- a/app/assets/javascripts/krudmin/core_theme/app.js
+++ b/app/assets/javascripts/krudmin/core_theme/app.js
@@ -28,6 +28,12 @@ function controllerPath() {
   return `${$('body').data('controller')}-${$('body').data('action')}`;
 }
 
+function panelNameFor(cardEl) {
+  var cPath = controllerPath();
+  var panelName = cardEl.data("card-panel");
+  return `${cPath}-${panelName}`;
+}
+
 document.addEventListener("turbofroms:updated", function(e) {
 });
 
@@ -94,6 +100,17 @@ document.addEventListener('turbolinks:load', function(event) {
     }
   });
 
+  $('.card-collapser').each(function(_, collapser) {
+    var cardEl = $(collapser).closest('.card');
+    var iconEl = $(collapser).find('i').get(0);
+    var panelName = panelNameFor(cardEl);
+
+    if (sessionStorage.getItem(panelName)) {
+      $(cardEl).find('.card-body').hide();
+      iconEl.className = iconEl.className.replace('fa-chevron-up', 'fa-chevron-down');
+    }
+  });
+
   initScripts();
   //Main navigation
   $.navigation = $('nav > ul.nav');
@@ -135,6 +152,31 @@ document.addEventListener('turbolinks:load', function(event) {
       window.dispatchEvent(new Event('resize'));
     }, 62.5);
   }
+  // console.warn();
+
+  $('.card-collapser').click(function (e) {
+    e.preventDefault();
+
+    var cPath = controllerPath();
+    var iconEl = $(this).find('i').get(0);
+    var cardEl = $(this).closest('.card');
+    var panelName = cardEl.data("card-panel");
+    var panelPath = `${cPath}-${panelName}`;
+    var cardBody = cardEl.find('.card-body');
+    var goesUp = iconEl.classList.contains("fa-chevron-up");
+
+    if (goesUp) {
+      cardBody.slideUp();
+      iconEl.className = iconEl.className.replace('fa-chevron-up', 'fa-chevron-down');
+      sessionStorage.setItem(panelPath, 'true');
+    } else {
+      cardBody.slideDown();
+      iconEl.className = iconEl.className.replace('fa-chevron-down', 'fa-chevron-up');
+      sessionStorage.removeItem(panelPath);
+    }
+
+    console.log(panelPath);
+  });
 
   /* ---------- Main Menu Open/Close, Min/Full ---------- */
   $('.sidebar-toggler').click(function(){
@@ -156,6 +198,11 @@ document.addEventListener('turbolinks:load', function(event) {
 
   $('.aside-menu-toggler').click(function(){
     $('body').toggleClass('aside-menu-hidden');
+    resizeBroadcast();
+  });
+
+  $('.search-panel-toggler').click(function () {
+    $('.search-panel').slideToggle('fast');
     resizeBroadcast();
   });
 

--- a/app/assets/stylesheets/krudmin/core_theme/core-ui/_custom.sass
+++ b/app/assets/stylesheets/krudmin/core_theme/core-ui/_custom.sass
@@ -56,6 +56,9 @@ body
     background: none
     border: none
   .card-body
+    @include media-breakpoint-down(md)
+      overflow-y: auto
+      overflow-x: scroll
     padding-top: 0px
     table
       thead
@@ -194,3 +197,23 @@ body
 
   @include media-breakpoint-down(md)
     margin-top: 130px
+
+
+.search-filter
+  background: #fdfdfd
+  padding: 10px
+  border-radius: 2px
+  border: 1px solid #efebeb
+  box-shadow: 0 1px 3px rgba(33, 33, 33, 0.2)
+  margin-top: 10px
+
+  .form-group
+    margin-bottom: 0px
+
+.hidden
+  display: none
+
+.main
+  @include media-breakpoint-down(sm)
+    .container-fluid
+      padding: 0 5px

--- a/app/views/krudmin/core_theme/_form.html.haml
+++ b/app/views/krudmin/core_theme/_form.html.haml
@@ -12,10 +12,7 @@
 
   = simple_form_for(model, validate: true, url: form_submit_path, html: { class: 'turbo-form form-horizontal' }) do |f|
     .row
-      - grouped_attributes.take(1).each do |key, metadata|
-        = render partial: "general_fields", locals: {metadata: metadata, f: f}
-
-      - grouped_attributes.drop(1).each do |key, metadata|
-        = render partial: "general_fields", locals: {metadata: metadata, f: f}
+      - grouped_attributes.each do |key, metadata|
+        = render partial: "general_fields", locals: {metadata: metadata, f: f, key: key}
 
     = render partial: "form_action_buttons", locals: {f: f}

--- a/app/views/krudmin/core_theme/_general_fields.html.haml
+++ b/app/views/krudmin/core_theme/_general_fields.html.haml
@@ -1,8 +1,11 @@
 %div{class: metadata.fetch(:class, 'col-lg-6 col-md-12')}
-  .card
+  .card{data: {card_panel: key}}
     .card-header
-      %h5
+      %h5.pull-left
         = metadata.fetch(:label)
+      .card-actions.pull-right
+        %a.btn.card-collapser{href: '#'}
+          %i.fa.fa-chevron-up.fa-lg
     .card-body
       .row
         - metadata.fetch(:attributes).each do |attribute|

--- a/app/views/krudmin/core_theme/_search_form.html.haml
+++ b/app/views/krudmin/core_theme/_search_form.html.haml
@@ -1,27 +1,31 @@
-- content_for(:aside) do
-  = simple_form_for(search_form, as: :q, method: :get, url: resource_root, html: { class: 'turbo-form' }) do |f|
-    = f.hidden_field :s
-    - search_form.fields.each_slice(2) do |field_slice|
-      .row
-        - field_slice.each do |field|
-          .col-lg-12
-            .form-group.row
-              .col-sm-12
-                %label
-                  %strong
-                    = model_class.human_attribute_name(field)
-              = field_for(field).render(:search, self, {form: f, search_form: search_form})
-    .row
-      .col-sm-12
-        %br
-        = button_tag(type: :submit, class: "btn btn-warning aside-menu-toggler") do
-          %i.fa.fa-search
-          = t('krudmin.actions.search')
-        &nbsp;
-        = link_to("#", class: "btn btn-danger aside-menu-toggler") do
-          %i.fa.fa-close
-          = t('krudmin.actions.cancel')
-        &nbsp;
-        = link_to(resource_root(reset_search: 1), class: "btn btn-light aside-menu-toggler") do
-          %i.fa.fa-close
-          = t('krudmin.actions.reset')
+.row.search-panel.hidden
+  .col-lg-12.no-padding
+    .card.items-list
+      .card-body
+        = simple_form_for(search_form, as: :q, method: :get, url: resource_root, html: { class: 'turbo-form' }) do |f|
+          = f.hidden_field :s
+          .row
+            - search_form.fields.each_slice(1) do |field_slice|
+              - field_slice.each do |field|
+                .col-lg-4.col-md-6
+                  .search-filter
+                    .form-group.row
+                      .col-sm-12
+                        %label
+                          %strong
+                            = model_class.human_attribute_name(field)
+                      = field_for(field).render(:search, self, {form: f, search_form: search_form})
+          .row
+            .col-sm-12
+              %br
+              = button_tag(type: :submit, class: "btn btn-primary search-panel-toggler") do
+                %i.fa.fa-search
+                = t('krudmin.actions.search')
+              &nbsp;
+              = link_to("#", class: "btn btn-danger search-panel-toggler") do
+                %i.fa.fa-close
+                = t('krudmin.actions.cancel')
+              &nbsp;
+              = link_to(resource_root(reset_search: 1), class: "btn btn-light search-panel-toggler") do
+                %i.fa.fa-close
+                = t('krudmin.actions.reset')

--- a/app/views/krudmin/core_theme/action_buttons/search_button/_list.html.haml
+++ b/app/views/krudmin/core_theme/action_buttons/search_button/_list.html.haml
@@ -1,3 +1,3 @@
-= link_to(action_path, class: "btn btn-warning aside-menu-toggler") do
+= link_to(action_path, class: "btn btn-warning search-panel-toggler") do
   %i.fa.fa-search
   = t('krudmin.actions.search')

--- a/app/views/krudmin/core_theme/action_buttons/search_button/_list.html.haml
+++ b/app/views/krudmin/core_theme/action_buttons/search_button/_list.html.haml
@@ -1,3 +1,3 @@
-= link_to(action_path, class: "btn btn-warning search-panel-toggler") do
+= link_to(action_path, class: "btn btn-warning search-panel-displayer") do
   %i.fa.fa-search
   = t('krudmin.actions.search')

--- a/app/views/layouts/krudmin/core_theme.html.haml
+++ b/app/views/layouts/krudmin/core_theme.html.haml
@@ -22,7 +22,7 @@
 
     = yield(:head_content)
 
-  %body.app.header-fixed.sidebar-fixed.aside-menu-fixed.aside-menu-hidden{class: body_classes}
+  %body.app.header-fixed.sidebar-fixed.aside-menu-fixed.aside-menu-hidden{class: body_classes, data: {controller: controller_name, action: action_name}}
     #body-overlay
     = render partial: 'layouts/krudmin/core_theme/header'
     .app-body

--- a/app/views/layouts/krudmin/core_theme/_toolbar.html.haml
+++ b/app/views/layouts/krudmin/core_theme/_toolbar.html.haml
@@ -1,7 +1,7 @@
 .toolbar
   .container-fluid
     .row
-      .col-md-6
+      .col-md-6.toolbar-buttons
         = yield :toolbar
       .col-lg-4.col-md-12
         = render partial: 'layouts/krudmin/core_theme/breadcrumbs'

--- a/app/views/layouts/krudmin/core_theme/_top_menu_with_toolbar.html.haml
+++ b/app/views/layouts/krudmin/core_theme/_top_menu_with_toolbar.html.haml
@@ -3,7 +3,7 @@
 
   .container-fluid
     .row
-      .col-lg-6.col-md-12
+      .col-lg-6.col-md-12.toolbar-buttons
         = yield :toolbar
       .col-lg-6.col-md-12
         = render partial: 'layouts/krudmin/core_theme/breadcrumbs'

--- a/app/views/layouts/krudmin/core_theme_top_navbar.html.haml
+++ b/app/views/layouts/krudmin/core_theme_top_navbar.html.haml
@@ -22,7 +22,7 @@
 
     = yield(:head_content)
 
-  %body.app.header-fixed.sidebar-fixed.aside-menu-fixed.aside-menu-hidden{class: body_classes}
+  %body.app.header-fixed.sidebar-fixed.aside-menu-fixed.aside-menu-hidden{class: body_classes, data: {controller: controller_name, action: action_name}}
     #body-overlay
     .app-body
       %main.main

--- a/lib/krudmin/version.rb
+++ b/lib/krudmin/version.rb
@@ -1,3 +1,3 @@
 module Krudmin
-  VERSION = "0.1.7.8"
+  VERSION = "0.1.7.9"
 end

--- a/spec/support/page_features.rb
+++ b/spec/support/page_features.rb
@@ -30,7 +30,7 @@ module PageFeatures
   end
 
   def click_add_link
-    within('.toolbar') do
+    within('.toolbar-buttons') do
       click_link("Add")
     end
   end


### PR DESCRIPTION
- Bump gem version to 0.1.7.9
- New search panel displayed in top of listed items instead of pulled aside div from right.
- Collapsable card boxes and persist state.
- Add controller and action name to body data.

![collapsed-cards-in-form](https://user-images.githubusercontent.com/1702736/38183357-cf7de5cc-360d-11e8-928f-47c12db8bda0.png)
![collapsable-cards-in-form](https://user-images.githubusercontent.com/1702736/38183358-cf967ad8-360d-11e8-81df-5b4e3a3af974.png)
![new-search-panel](https://user-images.githubusercontent.com/1702736/38183359-cfab6682-360d-11e8-8561-900ede3599cd.png)
