### PR TITLE
Sweet confirm

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -358,9 +358,19 @@ Style/TrailingCommaInArguments:
     - no_comma
   Enabled: true
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInHashLiteral:
   Description: 'Checks for trailing comma in array and hash literals.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  StyleGuide: 'https://github.com/bbatsov/rubocop/blob/master/manual/cops_style.md#styletrailingcommainhashliteral'
+  EnforcedStyleForMultiline: comma
+  SupportedStylesForMultiline:
+    - comma
+    - consistent_comma
+    - no_comma
+  Enabled: true
+
+Style/TrailingCommaInArrayLiteral:
+  Description: 'Checks for trailing comma in array and hash literals.'
+  StyleGuide: 'https://github.com/bbatsov/rubocop/blob/master/manual/cops_style.md#styletrailingcommainarrayliteral'
   EnforcedStyleForMultiline: comma
   SupportedStylesForMultiline:
     - comma
@@ -465,7 +475,7 @@ Lint/CircularArgumentReference:
   Description: "Don't refer to the keyword argument in the default value."
   Enabled: false
 
-Lint/ConditionPosition:
+Layout/ConditionPosition:
   Description: >-
                  Checks for condition placed in a confusing position relative to
                  the keyword.
@@ -549,7 +559,7 @@ Lint/Void:
   Description: 'Possible use of operator/literal/variable in void context.'
   Enabled: false
 
-Lint/BlockAlignment:
+Layout/BlockAlignment:
   Enabled: false
 
 # Performance

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    krudmin (0.1.7.9.3)
+    krudmin (0.1.7.9.4)
       arbre
       bootstrap (~> 4.0.0)
       cocoon

--- a/app/assets/javascripts/krudmin/core_theme/app.js
+++ b/app/assets/javascripts/krudmin/core_theme/app.js
@@ -36,7 +36,7 @@ function panelNameFor(cardEl) {
 }
 
 document.addEventListener("turboforms:updated", function(e) {
-  setTimeout(() => {
+  setTimeout(function() {
     Turbolinks.dispatch("turbolinks:load");
   }, 100);
 });

--- a/app/assets/javascripts/krudmin/core_theme/application.js
+++ b/app/assets/javascripts/krudmin/core_theme/application.js
@@ -21,6 +21,7 @@
 //= require krudmin/vendor/daterangepicker
 //= require krudmin/vendor/js.cookie
 //= require krudmin/kjs
+//= require krudmin/sweet-confirm
 //= require krudmin/turbo-forms
 //= require krudmin/core_theme/constants
 //= require krudmin/core_theme/app

--- a/app/assets/javascripts/krudmin/sweet-confirm.js
+++ b/app/assets/javascripts/krudmin/sweet-confirm.js
@@ -1,20 +1,9 @@
 (function () {
-   function handleConfirm (element, event) {
-    if (!allowAction(element, event)) {
-      Rails.stopEverything(event);
-    }
+  function handleConfirm (element) {
+    showConfirmationDialog(element);
   }
 
-   function allowAction(element, event) {
-    if (element.getAttribute('data-sweet-confirm') === null) {
-      return true
-    }
-
-    showConfirmationDialog(element, event);
-    return false
-  }
-
-   function showConfirmationDialog(element, event) {
+   function showConfirmationDialog(element) {
     var title = $(element).data("title");
     var text = $(element).data("sweet-confirm");
     var icon = $(element).data('confirm-icon') || "warning";
@@ -28,22 +17,25 @@
       buttons: true,
     }).then(function (result) {
       if (result) {
-        var element = event.target.dataset.sweetConfirm ? event.target : $(event.target).closest('*[data-sweet-confirm]').get(0);
-
-        element.dataset.sweetConfirmTemp = element.dataset.sweetConfirm;
-        delete element.dataset.sweetConfirm;
-        element.click();
-        element.dataset.sweetConfirm = element.dataset.sweetConfirmTemp;
+        this.dataset.sweetConfirmTemp = this.dataset.sweetConfirm;
+        delete this.dataset.sweetConfirm;
+        this.click();
+        this.dataset.sweetConfirm = element.dataset.sweetConfirmTemp;
       }
-    }.bind(event));
+    }.bind(element));
   }
 
   document.addEventListener("turbolinks:load", function () {
     $('*[data-sweet-confirm]').click(function (e) {
       e.preventDefault();
 
-      handleConfirm(this, e);
-    });
-  })
+      var element = e.target.getAttribute('data-sweet-confirm') != null ? e.target : $(e.target).closest('*[data-sweet-confirm]').get(0);
 
+      if (element != null) {
+        Rails.stopEverything(e);
+
+        handleConfirm(element);
+      }
+    });
+  });
 }).call(this);

--- a/app/assets/javascripts/krudmin/sweet-confirm.js
+++ b/app/assets/javascripts/krudmin/sweet-confirm.js
@@ -3,7 +3,7 @@
     showConfirmationDialog(element);
   }
 
-   function showConfirmationDialog(element) {
+  function showConfirmationDialog(element) {
     var title = $(element).data("title");
     var text = $(element).data("sweet-confirm");
     var icon = $(element).data('confirm-icon') || "warning";

--- a/app/assets/javascripts/krudmin/sweet-confirm.js
+++ b/app/assets/javascripts/krudmin/sweet-confirm.js
@@ -1,0 +1,49 @@
+(function () {
+   function handleConfirm (element, event) {
+    if (!allowAction(element, event)) {
+      Rails.stopEverything(event);
+    }
+  }
+
+   function allowAction(element, event) {
+    if (element.getAttribute('data-sweet-confirm') === null) {
+      return true
+    }
+
+    showConfirmationDialog(element, event);
+    return false
+  }
+
+   function showConfirmationDialog(element, event) {
+    var title = $(element).data("title");
+    var text = $(element).data("sweet-confirm");
+    var icon = $(element).data('confirm-icon') || "warning";
+    var className = ["sweet", $(element).data("confirm-class")].join('-');
+
+    swal({
+      title: title,
+      text: text,
+      icon: icon,
+      className: className,
+      buttons: true,
+    }).then(function (result) {
+      if (result) {
+        var element = event.target.dataset.sweetConfirm ? event.target : $(event.target).closest('*[data-sweet-confirm]').get(0);
+
+        element.dataset.sweetConfirmTemp = element.dataset.sweetConfirm;
+        delete element.dataset.sweetConfirm;
+        element.click();
+        element.dataset.sweetConfirm = element.dataset.sweetConfirmTemp;
+      }
+    }.bind(event));
+  }
+
+  document.addEventListener("turbolinks:load", function () {
+    $('*[data-sweet-confirm]').click(function (e) {
+      e.preventDefault();
+
+      handleConfirm(this, e);
+    });
+  })
+
+}).call(this);

--- a/app/assets/stylesheets/krudmin/core_theme/core-ui/_custom.sass
+++ b/app/assets/stylesheets/krudmin/core_theme/core-ui/_custom.sass
@@ -217,3 +217,35 @@ body
   @include media-breakpoint-down(sm)
     .container-fluid
       padding: 0 5px
+
+.sweet-primary
+  .swal-button--confirm
+    background-color: $blue
+
+.sweet-secondary
+  .swal-button--confirm
+    background-color: $gray-300
+
+.sweet-success
+  .swal-button--confirm
+    background-color: $green
+
+.sweet-info
+  .swal-button--confirm
+    background-color: $cyan
+
+.sweet-warning
+  .swal-button--confirm
+    background-color: $yellow
+
+.sweet-danger
+  .swal-button--confirm
+    background-color: $red
+
+.sweet-light
+  .swal-button--confirm
+    background-color: $gray-100
+
+.sweet-dark
+  .swal-button--confirm
+    background-color: $gray-800

--- a/app/views/krudmin/core_theme/action_buttons/active_button/_form.html.haml
+++ b/app/views/krudmin/core_theme/action_buttons/active_button/_form.html.haml
@@ -1,8 +1,8 @@
 - if model.active? && deactivate_access?(model)
-  = link_to(deactivate_path(model, context: :form), method: :post, remote: true, data: {confirm: confirm_deactivation_message(model)}, class: "btn btn-warning btn-disable btn-deactivate-item") do
+  = link_to(deactivate_path(model, context: :form), method: :post, remote: true, data: {confirm_class: :warning, confirm_icon: :warning, sweet_confirm: confirm_deactivation_message(model)}, class: "btn btn-warning btn-disable btn-deactivate-item") do
     %i.fa.fa-times
     = t('krudmin.actions.deactivate')
 - elsif !model.active? && activate_access?(model)
-  = link_to(activate_path(model, context: :form), method: :post, remote: true, data: {confirm: confirm_activation_message(model) }, class: "btn btn-success btn-enable btn-activate-item") do
+  = link_to(activate_path(model, context: :form), method: :post, remote: true, data: {confirm_class: :success, confirm_icon: :info, sweet_confirm: confirm_activation_message(model) }, class: "btn btn-success btn-enable btn-activate-item") do
     %i.fa.fa-check
     = t('krudmin.actions.activate')

--- a/app/views/krudmin/core_theme/action_buttons/active_button/_list.html.haml
+++ b/app/views/krudmin/core_theme/action_buttons/active_button/_list.html.haml
@@ -1,7 +1,7 @@
 %li.list-inline-item
   - if model.active? && deactivate_access?(model)
-    = link_to(deactivate_path(model), method: :post, remote: true, data: {confirm: confirm_deactivation_message(model)}, class: "btn btn-outline-warning btn-disable btn-deactivate-item") do
+    = link_to(deactivate_path(model), method: :post, remote: true, data: {confirm_class: :warning, confirm_icon: :warning, sweet_confirm: confirm_deactivation_message(model)}, class: "btn btn-outline-warning btn-disable btn-deactivate-item") do
       %i.fa.fa-times
   - elsif !model.active? && activate_access?(model)
-    = link_to(activate_path(model), method: :post, remote: true, data: {confirm: confirm_activation_message(model) }, class: "btn btn-outline-success btn-enable btn-activate-item") do
+    = link_to(activate_path(model), method: :post, remote: true, data: {confirm_class: :success, confirm_icon: :info, sweet_confirm: confirm_activation_message(model)}, class: "btn btn-outline-success btn-enable btn-activate-item") do
       %i.fa.fa-check

--- a/app/views/krudmin/core_theme/action_buttons/destroy_button/_list.html.haml
+++ b/app/views/krudmin/core_theme/action_buttons/destroy_button/_list.html.haml
@@ -1,4 +1,4 @@
 - if destroy_access?(model)
   .list-inline-item
-    = link_to(resource_path(model), method: :delete, remote: true, data: {confirm_class: :danger, confirm_icon: :error, confirm: confirm_destroy_message(model)}, class: "btn btn-outline-danger delete-btn btn-destroy-item") do
+    = link_to(resource_path(model), method: :delete, remote: true, data: {confirm_class: :danger, confirm_icon: :error, sweet_confirm: confirm_destroy_message(model)}, class: "btn btn-outline-danger delete-btn btn-destroy-item") do
       %i.fa.fa-trash

--- a/app/views/krudmin/core_theme/action_buttons/destroy_button/_list.html.haml
+++ b/app/views/krudmin/core_theme/action_buttons/destroy_button/_list.html.haml
@@ -1,4 +1,4 @@
 - if destroy_access?(model)
   .list-inline-item
-    = link_to(resource_path(model), method: :delete, remote: true, data: {confirm: confirm_destroy_message(model)}, class: "btn btn-outline-danger delete-btn btn-destroy-item") do
+    = link_to(resource_path(model), method: :delete, remote: true, data: {confirm_class: :danger, confirm_icon: :error, confirm: confirm_destroy_message(model)}, class: "btn btn-outline-danger delete-btn btn-destroy-item") do
       %i.fa.fa-trash

--- a/app/views/layouts/krudmin/core_theme.html.haml
+++ b/app/views/layouts/krudmin/core_theme.html.haml
@@ -18,6 +18,8 @@
     = stylesheet_link_tag    'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/css/select2.min.css'
     = stylesheet_link_tag    'https://select2.github.io/select2-bootstrap-theme/css/select2-bootstrap.css'
 
+    = javascript_include_tag "https://unpkg.com/sweetalert/dist/sweetalert.min.js"
+
     = render partial: 'layouts/krudmin/core_theme/head_content'
 
     = yield(:head_content)

--- a/app/views/layouts/krudmin/core_theme_top_navbar.html.haml
+++ b/app/views/layouts/krudmin/core_theme_top_navbar.html.haml
@@ -18,6 +18,8 @@
     = stylesheet_link_tag    'https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/css/select2.min.css'
     = stylesheet_link_tag    'https://select2.github.io/select2-bootstrap-theme/css/select2-bootstrap.css'
 
+    = javascript_include_tag "https://unpkg.com/sweetalert/dist/sweetalert.min.js"
+
     = render partial: 'layouts/krudmin/core_theme/head_content'
 
     = yield(:head_content)

--- a/lib/krudmin/params_parser.rb
+++ b/lib/krudmin/params_parser.rb
@@ -27,7 +27,7 @@ module Krudmin
         if metadata && raw_value.present?
           case metadata.type
           when :datetime
-            Time.strptime(raw_value, I18n.t("krudmin.datetime.input_format"))
+            Time.zone.strptime(raw_value, I18n.t("krudmin.datetime.input_format"))
           when :date
             Date.strptime(raw_value, I18n.t("krudmin.date.input_format"))
           else raw_value

--- a/lib/krudmin/version.rb
+++ b/lib/krudmin/version.rb
@@ -1,3 +1,3 @@
 module Krudmin
-  VERSION = "0.1.7.9.3"
+  VERSION = "0.1.7.9.4"
 end


### PR DESCRIPTION
- Adds confirm dialogs with sweet alert
- Confirm options
  - confirm_class: This class will wrap the confirm dialog div, there are pre-configured classes for standard bootstrap colors: primary, secondary, success, warning, info, danger, etc....., those classes will define the color of the OK button.
  - confirm_icon: Will configure the sweet alert icon shown.
  - sweet_confirm: Displayed message.
  - title: Title of the sweet modal.

![screen shot 2018-04-09 at 1 25 12 am](https://user-images.githubusercontent.com/1702736/38480676-e4869978-3b94-11e8-9e5b-25eefb51698b.png)
![screen shot 2018-04-09 at 1 24 51 am](https://user-images.githubusercontent.com/1702736/38480677-e49e2264-3b94-11e8-8ca6-d3cfb7520b08.png)
![screen shot 2018-04-09 at 1 24 41 am](https://user-images.githubusercontent.com/1702736/38480678-e4b7d6be-3b94-11e8-9c38-1be9010a5faf.png)
