### PR TITLE
Allow to set custom labels for all contexts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ public/assets/
 spec/test_app/public/assets/
 tmp/caching-dev.txt
 tmp/rspec_guard_result
+
+.vscode/settings.json
+
+.ruby-gemset

--- a/app/views/krudmin/core_theme/_search_form.html.haml
+++ b/app/views/krudmin/core_theme/_search_form.html.haml
@@ -10,10 +10,6 @@
                 .col-lg-4.col-md-6
                   .search-filter
                     .form-group.row
-                      .col-sm-12
-                        %label
-                          %strong
-                            = model_class.human_attribute_name(field)
                       = field_for(field).render(:search, self, {form: f, search_form: search_form})
           .row
             .col-sm-12

--- a/app/views/krudmin/core_theme/fields/base/_search.html.haml
+++ b/app/views/krudmin/core_theme/fields/base/_search.html.haml
@@ -1,3 +1,7 @@
+.col-sm-12
+  %label
+    %strong
+      = field_label
 .col-sm-5
   %ul.list-unstyled
     %li

--- a/app/views/krudmin/core_theme/fields/belongs_to/_search.html.haml
+++ b/app/views/krudmin/core_theme/fields/belongs_to/_search.html.haml
@@ -1,3 +1,7 @@
+.col-sm-12
+  %label
+    %strong
+      = field_label
 %ul.list-unstyled.col-sm-12
   %li
     = form.hidden_field(options_attribute, required: false, class: "form-control", value: :eq)

--- a/app/views/krudmin/core_theme/fields/boolean/_search.html.haml
+++ b/app/views/krudmin/core_theme/fields/boolean/_search.html.haml
@@ -1,3 +1,7 @@
+.col-sm-12
+  %label
+    %strong
+      = field_label
 %ul.list-unstyled.col-sm-12
   %li
     = form.hidden_field(attribute, required: false, class: "form-control", value: true)

--- a/app/views/krudmin/core_theme/fields/date/_search.html.haml
+++ b/app/views/krudmin/core_theme/fields/date/_search.html.haml
@@ -1,3 +1,7 @@
+.col-sm-12
+  %label
+    %strong
+      = field_label
 - search_options.each do |search_option|
   .col-sm-6
     %ul.list-unstyled

--- a/app/views/krudmin/core_theme/fields/date_time/_search.html.haml
+++ b/app/views/krudmin/core_theme/fields/date_time/_search.html.haml
@@ -1,3 +1,7 @@
+.col-sm-12
+  %label
+    %strong
+      = field_label
 - search_options.each do |search_option|
   .col-sm-6
     %ul.list-unstyled

--- a/app/views/krudmin/core_theme/fields/email/_search.html.haml
+++ b/app/views/krudmin/core_theme/fields/email/_search.html.haml
@@ -1,3 +1,7 @@
+.col-sm-12
+  %label
+    %strong
+      = field_label
 .col-sm-5
   %ul.list-unstyled
     %li

--- a/app/views/krudmin/core_theme/fields/enum_type/_search.html.haml
+++ b/app/views/krudmin/core_theme/fields/enum_type/_search.html.haml
@@ -1,3 +1,7 @@
+.col-sm-12
+  %label
+    %strong
+      = field_label
 %ul.list-unstyled.col-sm-12
   %li
     = form.hidden_field(options_attribute, required: false, class: "form-control", value: :eq)

--- a/app/views/krudmin/core_theme/fields/number/_search.html.haml
+++ b/app/views/krudmin/core_theme/fields/number/_search.html.haml
@@ -1,3 +1,7 @@
+.col-sm-12
+  %label
+    %strong
+      = field_label
 .col-sm-5
   %ul.list-unstyled
     %li

--- a/app/views/krudmin/core_theme/fields/rich_text/_search.html.haml
+++ b/app/views/krudmin/core_theme/fields/rich_text/_search.html.haml
@@ -1,3 +1,7 @@
+.col-sm-12
+  %label
+    %strong
+      = field_label
 .col-sm-5
   %ul.list-unstyled
     %li

--- a/app/views/krudmin/core_theme/fields/string/_search.html.haml
+++ b/app/views/krudmin/core_theme/fields/string/_search.html.haml
@@ -1,3 +1,7 @@
+.col-sm-12
+  %label
+    %strong
+      = field_label
 .col-sm-5
   %ul.list-unstyled
     %li

--- a/app/views/krudmin/core_theme/fields/text/_search.html.haml
+++ b/app/views/krudmin/core_theme/fields/text/_search.html.haml
@@ -1,3 +1,7 @@
+.col-sm-12
+  %label
+    %strong
+      = field_label
 .col-sm-5
   %ul.list-unstyled
     %li

--- a/app/views/krudmin/core_theme/index.html.haml
+++ b/app/views/krudmin/core_theme/index.html.haml
@@ -27,7 +27,7 @@
             %tr
               - listable_attributes.each_with_index do |column_label, column_index|
                 %th{class: "#{krudmin_manager.field_for(column_label).html_class}"}
-                  = sort_link items, column_label, model_class.human_attribute_name(column_label), o: search_form.search_criteria
+                  = sort_link items, column_label, krudmin_manager.field_for(column_label).options.fetch(:input, {}).fetch(:label, model_class.human_attribute_name(column_label)) , o: search_form.search_criteria
               - if listable_actions.any?
                 %th{width: "20%"}= t('krudmin.actions.label')
           %tbody

--- a/lib/krudmin/presenters/base_field_presenter.rb
+++ b/lib/krudmin/presenters/base_field_presenter.rb
@@ -54,6 +54,18 @@ module Krudmin
         render_partial(:search, search_form: search_form, options_attribute: options_attribute)
       end
 
+      def model_class
+        if field.model
+          field.model.class
+        elsif search_form
+          search_form.model_class
+        end
+      end
+
+      def field_label
+        input_options.fetch(:label, model_class.human_attribute_name(attribute))
+      end
+
       private
 
       def options_attribute
@@ -83,7 +95,7 @@ module Krudmin
       end
 
       def default_locals
-        { field: field, form: form, input_options: input_options, attribute: attribute, options: options }
+        { field: field, form: form, input_options: input_options, attribute: attribute, options: options, field_label: field_label }
       end
 
       def form

--- a/spec/features/cars/car_edit_spec.rb
+++ b/spec/features/cars/car_edit_spec.rb
@@ -20,6 +20,7 @@ describe "line item index page", type: :feature do
   it "shows checkbox field for boolean type" do
     click_edit_link_for(car)
     expect(car_page).to have_css 'input#car_active'
+    expect(car_page).to have_content 'Is Active'
   end
 
   it "shows the rich text field type" do

--- a/spec/features/cars/car_index_spec.rb
+++ b/spec/features/cars/car_index_spec.rb
@@ -15,6 +15,10 @@ describe "line item index page", type: :feature do
     expect(car_page).to have_model_visible
   end
 
+  it "renders a custom label in the index page" do
+    expect(car_page).to have_content 'Is Active'
+  end
+
   it "links to the show page of a given item" do
     click_show_link_for(car)
 

--- a/spec/test_app/app/resource_managers/cars_resource_manager.rb
+++ b/spec/test_app/app/resource_managers/cars_resource_manager.rb
@@ -29,7 +29,7 @@ class CarsResourceManager < Krudmin::ResourceManagers::Base
     model: { type: :Text, input: { rows: 2 } },
     description: { type: :RichText, show_length: 20 },
     year: :Number,
-    active: :Boolean,
+    active: { type: :Boolean, input: { label: 'Is Active'} },
     passengers: :HasMany,
     car_brand_id: { type: :BelongsTo, collection_label_field: :description, association_path: :admin_car_brand_path, add_path: :new_admin_car_brand, edit_path: :edit_admin_car_brand },
     created_at: { type: :DateTime, format: :short },

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180211180752) do
+ActiveRecord::Schema.define(version: 2018_02_11_180752) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Now a custom label can be set by specifying the key `label` in the input options hash of the respective field of `ATTRIBUTE_TYPES` configuration.

```ruby
ATTRIBUTE_TYPES = {
    active: { type: :Boolean, input: { label: 'Is Active'} }
  }
```