### PR TITLE
Add autocomplete capabilities to belongs to fields

### DIFF
--- a/app/assets/javascripts/krudmin/core_theme/app.js
+++ b/app/assets/javascripts/krudmin/core_theme/app.js
@@ -279,7 +279,7 @@ document.addEventListener('updateBelongsToLookups', function (e) {
     return field_name;
   });
 
-  $.get(window.location, { format: "json", fields: _field_names }).done(function (_data) {
+  $.get(window.location, { format: "json", fields: _field_names, search_id: _model_id}).done(function (_data) {
     var mod_id = _model_id;
     var data = _data;
     var field_names = _field_names;

--- a/app/assets/javascripts/krudmin/core_theme/app.js
+++ b/app/assets/javascripts/krudmin/core_theme/app.js
@@ -270,24 +270,25 @@ function clearToasts() {
 }
 
 document.addEventListener('updateBelongsToLookups', function (e) {
-  if (!document.body.dataset.modelId) {
-    return;
-  }
-
   var model_element = e.detail.model_element;
-  var _relations = e.detail.relations;
+  var relations = e.detail.relations;
   var _model_id = e.detail.model_id;
 
-  $.get(window.location, {format: "json"}).done(function (_data) {
-    var relations = _relations;
+  var _field_names = $.map(relations, function (index) {
+    var field_name = model_element + "_id";
+    return field_name;
+  });
+
+  $.get(window.location, { format: "json", fields: _field_names }).done(function (_data) {
     var mod_id = _model_id;
     var data = _data;
+    var field_names = _field_names;
 
-    $(relations).each(function (index) {
+    $(field_names).each(function (index) {
+      var field_name = field_names[index];
       var formSelector = "form[data-model-element='" + relations[index] + "']";
       var targetForm = $(formSelector);
       var model_element_name = targetForm.data('model-element');
-      var field_name = model_element + "_id";
       var field_id = ["#", model_element_name, "_", field_name].join("");
       var targetLookup = targetForm.find(field_id);
       var field_data = data[field_name];

--- a/app/assets/javascripts/krudmin/select2-adapter.js
+++ b/app/assets/javascripts/krudmin/select2-adapter.js
@@ -1,13 +1,55 @@
+function initRemoteSelect(_element) {
+  var element = _element;
+
+  $(element).select2({
+    width: '100%',
+    ajax: {
+      url: window.location,
+      dataType: 'json',
+      delay: 300,
+      data: function (params) {
+        return {
+          search_term: params.term,
+          fields: this.dataset.field,
+          format: "json"
+        };
+      }.bind(element),
+      processResults: function (data) {
+        var textProperty = data[this.dataset.field].collection_label_field;
+
+        var items = $.map(data[this.dataset.field].options, function (item) {
+          return {
+            id: item.id,
+            text: item[textProperty]
+          };
+        });
+
+        return {
+          results: items
+        };
+      }.bind(element)
+    }
+  });
+}
+
 function initializeTurboSelect2(container) {
   container = container || "*";
 
   $.fn.select2.defaults.set("theme", "bootstrap");
 
-  $(container).find("select.select2").select2({ width: '100%' });
+  var selectControls = $(container).find("select.select2");
+
+  selectControls.each(function(_, element) {
+    if (element.dataset.remote && element.dataset.remote.toLowerCase() == "true") {
+      initRemoteSelect(element);
+    } else {
+      $(element).select2({ width: '100%' });
+    }
+  });
 
   $(container).find("select.taglist").select2({ tags: true, width: '100%'  });
 
-  $(container).find("select.select2-multiple[multiple]").select2({ multiple: true, width: '100%'  });
+  $(container).find("select.select2-multiple[multiple]").select2({ multiple: true, width: '100%' });
 }
 
 $(document).on('turbolinks:load', function () {

--- a/app/controllers/krudmin/application_controller.rb
+++ b/app/controllers/krudmin/application_controller.rb
@@ -13,6 +13,7 @@ module Krudmin
 
     before_action :set_view_path
     before_action :set_model, only: [:new, :edit, :create]
+    helper_method :requested_editable_fields, :search_term
 
     def index; end
 
@@ -70,6 +71,15 @@ module Krudmin
 
     def set_view_path
       lookup_context.prefixes.append Krudmin::Config.theme
+    end
+
+    def requested_editable_fields
+      requested_fields = Array(params[:fields]).map(&:to_sym)
+      requested_fields.any? ? (editable_attributes & requested_fields) : editable_attributes
+    end
+
+    def search_term
+      params[:search_term]
     end
   end
 end

--- a/app/controllers/krudmin/application_controller.rb
+++ b/app/controllers/krudmin/application_controller.rb
@@ -13,7 +13,7 @@ module Krudmin
 
     before_action :set_view_path
     before_action :set_model, only: [:new, :edit, :create]
-    helper_method :requested_editable_fields, :search_term
+    helper_method :requested_editable_fields, :search_term, :search_id
 
     def index; end
 
@@ -80,6 +80,10 @@ module Krudmin
 
     def search_term
       params[:search_term]
+    end
+
+    def search_id
+      params[:search_id]
     end
   end
 end

--- a/app/views/krudmin/core_theme/_form.json.erb
+++ b/app/views/krudmin/core_theme/_form.json.erb
@@ -12,8 +12,8 @@
 %>
 <% else %>
   <%=
-  editable_attributes.map.inject({}) do |hash, attribute|
-    hash[attribute] = field_for(attribute, model).render(:json, self, {})
+  requested_editable_fields.map.inject({}) do |hash, attribute|
+    hash[attribute] = field_for(attribute, model).render(:json, self, { search_term: search_term, remote_search: true })
     hash
   end.to_json.html_safe
   %>

--- a/app/views/krudmin/core_theme/_form.json.erb
+++ b/app/views/krudmin/core_theme/_form.json.erb
@@ -13,7 +13,7 @@
 <% else %>
   <%=
   requested_editable_fields.map.inject({}) do |hash, attribute|
-    hash[attribute] = field_for(attribute, model).render(:json, self, { search_term: search_term, remote_search: true })
+    hash[attribute] = field_for(attribute, model).render(:json, self, { search_term: search_term, search_id: search_id, remote_search: true })
     hash
   end.to_json.html_safe
   %>

--- a/app/views/krudmin/core_theme/fields/belongs_to/_form_field.html.haml
+++ b/app/views/krudmin/core_theme/fields/belongs_to/_form_field.html.haml
@@ -1,5 +1,5 @@
 .associated-resource-container
-  = form.association association_name, label: field_label, as: input_type, collection: associated_options, label_method: collection_label_field, value_method: :id, group_method: group_method, group_label_method: group_label_method, input_html: {class: 'form-control select2 belongs-to-control', include_blank: true}
+  = form.association association_name, label: field_label, as: input_type, collection: associated_options, label_method: collection_label_field, value_method: :id, group_method: group_method, group_label_method: group_label_method, input_html: { class: 'form-control select2 belongs-to-control', include_blank: true, data: { remote: remote, field: attribute } }
 
   - if add_path || edit_path
     .row

--- a/lib/krudmin/presenters/belongs_to_field_presenter.rb
+++ b/lib/krudmin/presenters/belongs_to_field_presenter.rb
@@ -1,7 +1,7 @@
 module Krudmin
   module Presenters
     class BelongsToFieldPresenter < BaseFieldPresenter
-      delegate :associated_options, :collection_label_field, :association_name, :association_path, :link_to_path, :humanized_value, :group_method, :group_label_method, to: :field
+      delegate :collection_label_field, :association_name, :association_path, :link_to_path, :humanized_value, :group_method, :group_label_method, to: :field
       delegate :input_type, :associated_resource_manager_class, :edit_path, :add_path, to: :field
 
       alias linkable? association_path
@@ -31,6 +31,7 @@ module Krudmin
                               associated_model: associated_model,
                               add_path: add_path,
                               edit_path: edit_path,
+                              remote: remote?,
                               associated_resource_label: associated_resource_label,
                               associated_resource_manager_class: associated_resource_manager_class)
       end
@@ -45,6 +46,7 @@ module Krudmin
                                 group_method: group_method,
                                 group_label_method: group_label_method,
                                 input_type: input_type,
+                                remote: remote?,
                                 associated_resource_manager_class: associated_resource_manager_class)
       end
 
@@ -52,6 +54,32 @@ module Krudmin
         render_partial(:show, humanized_value: humanized_value,
                               linkable: linkable?,
                               link_to_association: ->(view_context) { link_to_path(view_context) })
+      end
+
+      def associated_options
+        if remote? && !remote_search?
+          field.associated_options.where(id: field.value)
+        elsif remote_search?
+          field.associated_options.send(search_by_term_scope, search_term)
+        else
+          field.associated_options
+        end
+      end
+
+      def search_by_term_scope
+        field.options.fetch(:search_by_term_scope, :search_by_term)
+      end
+
+      def search_term
+        options[:search_term]
+      end
+
+      def remote?
+        field.options[:remote]
+      end
+
+      def remote_search?
+        options[:remote_search]
       end
 
       def standarized_associated_options

--- a/lib/krudmin/presenters/belongs_to_field_presenter.rb
+++ b/lib/krudmin/presenters/belongs_to_field_presenter.rb
@@ -59,6 +59,8 @@ module Krudmin
       def associated_options
         if remote? && !remote_search?
           field.associated_options.where(id: field.value)
+        elsif search_id
+          field.associated_options.where(id: search_id)
         elsif remote_search?
           field.associated_options.send(search_by_term_scope, search_term)
         else
@@ -72,6 +74,10 @@ module Krudmin
 
       def search_term
         options[:search_term]
+      end
+
+      def search_id
+        options[:search_id]
       end
 
       def remote?

--- a/spec/features/cars/car_edit_spec.rb
+++ b/spec/features/cars/car_edit_spec.rb
@@ -39,7 +39,9 @@ describe "line item index page", type: :feature do
     click_edit_link_for(car)
 
     expect(car_page).to have_selector :select, "car[car_brand_id]", selected: "Toyota"
-    expect(page).to have_selector :select, "car[car_brand_id]", with_options: ["Toyota", "Honda"]
+    # expect(page).to have_selector :select, "car[car_brand_id]", with_options: ["Toyota", "Honda"]
+    # Only Toyota is visible, because this is a remote select and only the selected option is loaded
+    expect(page).to have_selector :select, "car[car_brand_id]", with_options: ["Toyota"]
   end
 
   it "shows the email field type" do

--- a/spec/features/cars/car_new_spec.rb
+++ b/spec/features/cars/car_new_spec.rb
@@ -16,7 +16,8 @@ describe "line item index page", type: :feature do
 
     fill_in(:car_model, with: car_model)
     fill_in(:car_year, with: 2009)
-    select('Toyota', from: :car_car_brand_id)
+    # For now the car brand will be optional, because now this is a remote select and by default no options are loaded
+    # select('Toyota', from: :car_car_brand_id)
 
     car_page.click_save_model_button
 

--- a/spec/test_app/app/models/car.rb
+++ b/spec/test_app/app/models/car.rb
@@ -11,7 +11,7 @@ class Car < ApplicationRecord
   scope :active, -> { where(active: true) }
   scope :inactive, -> { where(active: false) }
 
-  belongs_to :car_brand
+  belongs_to :car_brand, optional: true
 
   enum transmission: {automatic: 0, manual: 1}
 

--- a/spec/test_app/app/models/car_brand.rb
+++ b/spec/test_app/app/models/car_brand.rb
@@ -2,4 +2,6 @@ class CarBrand < ApplicationRecord
   validates :description, uniqueness: true, presence: true
 
   has_many :cars
+
+  scope :search_by_term, -> (term) { where("description ILIKE ?", "%#{term}%").limit(10) }
 end

--- a/spec/test_app/app/resource_managers/cars_resource_manager.rb
+++ b/spec/test_app/app/resource_managers/cars_resource_manager.rb
@@ -31,7 +31,7 @@ class CarsResourceManager < Krudmin::ResourceManagers::Base
     year: :Number,
     active: { type: :Boolean, input: { label: 'Is Active'} },
     passengers: :HasMany,
-    car_brand_id: { type: :BelongsTo, collection_label_field: :description, association_path: :car_brand_path, add_path: :new_car_brand, edit_path: :edit_car_brand },
+    car_brand_id: { type: :BelongsTo, collection_label_field: :description, association_path: :car_brand_path, add_path: :new_car_brand, edit_path: :edit_car_brand, remote: true },
     created_at: { type: :DateTime, format: :short },
     release_date: { type: :Date, format: :short },
     transmission: { type: :EnumType, associated_options: -> { Car.transmissions } },


### PR DESCRIPTION
- Associated relation will need to define an scope named `search_by_term`, or override the name of the scope in the attribute definition on the resource manager, e.g: 
```ruby
{ type: :BelongsTo, search_by_term_scope:, :search_by_something }

# name of the custom scope: `search_by_something `
```
- Now remote select boxes will only load the selected item by default, on forms for new records, no options will be loaded.