### PR TITLE
passing down options to know the resource_manager_class_name on has_many

### DIFF
--- a/lib/krudmin/fields/has_many.rb
+++ b/lib/krudmin/fields/has_many.rb
@@ -54,7 +54,7 @@ module Krudmin
       def self.type_as_hash(attribute, options)
         {
           attribute => options,
-          __attributes: Krudmin::ResourceManagers::Attribute.from_list(new(attribute).associated_resource_manager_class::ATTRIBUTE_TYPES),
+          __attributes: Krudmin::ResourceManagers::Attribute.from_list(new(attribute, nil, options).associated_resource_manager_class::ATTRIBUTE_TYPES),
         }
       end
     end


### PR DESCRIPTION
the `associated_resource_manager_class` could not infer the proper resource_manager for associations that doesn't match with the name of the resource_manger but since we specified the resource_manager class in the fields options, we can pass down the options and the `associated_resource_manager_class` will return the the resource_manager defined fo this field.