### PR TITLE
Display user friendly error messages when accepts_nested_attributes_for is not defined for associations

### DIFF
--- a/app/views/krudmin/core_theme/fields/belongs_to_one/_form_fields.html.haml
+++ b/app/views/krudmin/core_theme/fields/belongs_to_one/_form_fields.html.haml
@@ -1,6 +1,6 @@
 - field.model.send(attribute) or field.model.send("build_#{attribute}")
 
-- form.simple_fields_for field.attribute do |f|
+- form.simple_fields_for field.attribute_for_nested_form do |f|
   = f.hidden_field :id if field.model.send(attribute)&.id
   = f.hidden_field :_destroy, class: "destroy_model_check"
 

--- a/app/views/krudmin/core_theme/fields/has_many/_form_field.html.haml
+++ b/app/views/krudmin/core_theme/fields/has_many/_form_field.html.haml
@@ -9,7 +9,7 @@
             = field.associated_resource_manager_class.model_class.human_attribute_name(attribute)
       %th
   %tbody{id: "krudmin-nested-fields-#{field.association_name}"}
-    = form.simple_fields_for field.association_name do |builder|
+    = form.simple_fields_for field.attribute_for_nested_form do |builder|
       = render_partial.call(field.child_partial_form, f: builder, field: field)
   %tfoot
     %tr

--- a/app/views/krudmin/core_theme/fields/has_one/_form_fields.html.haml
+++ b/app/views/krudmin/core_theme/fields/has_one/_form_fields.html.haml
@@ -1,6 +1,6 @@
 - field.model.send(attribute) or field.model.send("build_#{attribute}")
 
-- form.simple_fields_for field.attribute do |f|
+- form.simple_fields_for field.attribute_for_nested_form do |f|
   = f.hidden_field :id if field.model.send(attribute)&.id
   = f.hidden_field :_destroy, class: "destroy_model_check"
 

--- a/lib/krudmin/fields/associated.rb
+++ b/lib/krudmin/fields/associated.rb
@@ -1,6 +1,8 @@
 module Krudmin
   module Fields
     class Associated < Base
+      class UndefinedAcceptsNestedAtributesForAssociation < StandardError; end
+
       def associated_class
         associated_class_name.constantize
       end
@@ -43,6 +45,18 @@ module Krudmin
 
       def edit_path
         options[:edit_path]
+      end
+
+      def attribute_for_nested_form
+        validate_nested_attributes_for_association!
+
+        association_name
+      end
+
+      def validate_nested_attributes_for_association!
+        msg = "`accepts_nested_attributes_for :#{association_name}` needs to be defined in #{model.class.name}"
+
+        raise UndefinedAcceptsNestedAtributesForAssociation.new(msg) unless model.respond_to?("#{association_name}_attributes=")
       end
 
       private

--- a/spec/lib/krudmin/fields/associated_spec.rb
+++ b/spec/lib/krudmin/fields/associated_spec.rb
@@ -3,10 +3,8 @@ require "#{Dir.pwd}/lib/krudmin/fields/base"
 require "#{Dir.pwd}/lib/krudmin/fields/associated"
 
 describe Krudmin::Fields::Associated do
-  let(:data) { 1 }
+  let(:data) { OpenStruct.new }
   subject { described_class.new(:ranger_id, data) }
-
-
 
   context "inferred relations" do
     describe "association_name" do
@@ -38,6 +36,22 @@ describe Krudmin::Fields::Associated do
 
       it "infers the class of the association" do
         expect(subject.associated_class).to eq(Ranger)
+      end
+    end
+
+    describe "attribute_for_nested_form" do
+      context "when the association is ready for nested attributes" do
+        let(:data) { OpenStruct.new(ranger_attributes: nil) }
+
+        it "returns attribute for the given association" do
+          expect(subject.attribute_for_nested_form).to eq(:ranger)
+        end
+      end
+
+      context "when the association is not ready for nested attributes" do
+        it "raises an error indicating that accepts_nested_attributes_for needs to be defined for the given assocation" do
+          expect{ subject.attribute_for_nested_form }.to raise_error(described_class::UndefinedAcceptsNestedAtributesForAssociation, "`accepts_nested_attributes_for :ranger` needs to be defined in OpenStruct")
+        end
       end
     end
   end


### PR DESCRIPTION
![screen shot 2018-06-20 at 5 22 08 pm](https://user-images.githubusercontent.com/1702736/41685951-44e921a6-74b0-11e8-87de-d206980a1c0e.png)
